### PR TITLE
Remove address and email from find filter and sort feature

### DIFF
--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.model.internship.Internship.ATTRIBUTES_LIST;
+import static seedu.address.model.internship.Internship.SORTABLE_ATTRIBUTES_LIST;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,7 +19,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class SortCommandParser implements Parser<SortCommand> {
 
     private static final String MESSAGE_INVALID_SORT_ATTRIBUTE = "Invalid attributes given! Possible attributes are : "
-            + ATTRIBUTES_LIST;
+            + SORTABLE_ATTRIBUTES_LIST;
 
     /**
      * Parses the given {@code String} of arguments in the context of the SortCommand
@@ -38,7 +38,7 @@ public class SortCommandParser implements Parser<SortCommand> {
 
         // Checks if keywords are proper internship attributes
         if (!keywords.stream().allMatch(keyword ->
-                    StringUtil.containsWordIgnoreCase(ATTRIBUTES_LIST, keyword))) {
+                    StringUtil.containsWordIgnoreCase(SORTABLE_ATTRIBUTES_LIST, keyword))) {
             throw new ParseException(MESSAGE_INVALID_SORT_ATTRIBUTE);
         }
 

--- a/src/main/java/seedu/address/model/internship/Internship.java
+++ b/src/main/java/seedu/address/model/internship/Internship.java
@@ -15,7 +15,7 @@ import seedu.address.model.tag.UniqueTagList;
  */
 public class Internship {
 
-    public static final String ATTRIBUTES_LIST = "Name Salary Email Address Industry Region Role";
+    public static final String SORTABLE_ATTRIBUTES_LIST = "Name Salary Industry Region Role";
     private final Name name;
     private final Salary salary;
     private final Email email;
@@ -122,10 +122,6 @@ public class Internship {
         builder.append(getName())
                 .append(" Salary: ")
                 .append(getSalary())
-                .append(" Email: ")
-                .append(getEmail())
-                .append(" Address: ")
-                .append(getAddress())
                 .append(" Industry: ")
                 .append(getIndustry())
                 .append(" Region: ")
@@ -146,9 +142,6 @@ public class Internship {
         case "salary":
             return getSalary().toString();
 
-        case "address":
-            return getAddress().toString();
-
         case "industry":
             return getIndustry().toString();
 
@@ -157,9 +150,6 @@ public class Internship {
 
         case "role":
             return getRole().toString();
-
-        case "email":
-            return getEmail().toString();
 
         default:
             assert false; // Keyword already parsed to attribute type. Program should never reach here

--- a/src/main/java/seedu/address/model/internship/InternshipContainsAllKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/internship/InternshipContainsAllKeywordsPredicate.java
@@ -30,7 +30,7 @@ public class InternshipContainsAllKeywordsPredicate implements Predicate<Interns
     private String internshipAttributeString(Internship internship) {
         // tags currently toString as [tagName], replace [] with whitespace for searching.
         // Also replaces commas with whitespace
-        return new String(internship.toString().replaceAll("[\\[+\\]+\\,]", " "));
+        return internship.toString().replaceAll("[\\[+\\]+\\,]", " "));
     }
 
     @Override

--- a/src/test/java/seedu/address/model/internship/InternshipContainsAllKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/internship/InternshipContainsAllKeywordsPredicateTest.java
@@ -54,9 +54,6 @@ public class InternshipContainsAllKeywordsPredicateTest {
                 new InternshipContainsAllKeywordsPredicate(Collections.singletonList("Charlie"));
         assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
 
-        predicate = new InternshipContainsAllKeywordsPredicate(Collections.singletonList("ABC"));
-        assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
-
         predicate = new InternshipContainsAllKeywordsPredicate(Collections.singletonList("Data"));
         assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
 
@@ -70,17 +67,17 @@ public class InternshipContainsAllKeywordsPredicateTest {
         predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("Data", "Scientist"));
         assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
 
-        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("Data", "Tech", "ABC"));
+        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("Data", "Tech", "Company"));
         assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
 
         // Mixed-case keywords
         predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
 
-        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("DaTa", "ToWn", "aBc"));
+        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("DaTa", "ToWn", "COmpany"));
         assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
 
-        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("AbC@Example.com", "TECH"));
+        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("DaTa"));
         assertTrue(predicate.test(PREDICATE_TEST_INTERNSHIP));
 
         // Zero keywords
@@ -128,13 +125,13 @@ public class InternshipContainsAllKeywordsPredicateTest {
     public void test_canHandleNonAlphaNumericKeywords_returnsTrue() {
         // Can Handle Commas, [], and both
         InternshipContainsAllKeywordsPredicate predicate =
-                new InternshipContainsAllKeywordsPredicate(Arrays.asList("Street"));
-        assertTrue(predicate.test(new InternshipBuilder().withAddress("Street,").build()));
+                new InternshipContainsAllKeywordsPredicate(Arrays.asList("Test"));
+        assertTrue(predicate.test(new InternshipBuilder().withIndustry("Test,").build()));
 
         predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("saved"));
         assertTrue(predicate.test(new InternshipBuilder().withTags("[saved]").build()));
 
-        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("Street", "saved"));
-        assertTrue(predicate.test(new InternshipBuilder().withAddress("Street,").withTags("[saved]").build()));
+        predicate = new InternshipContainsAllKeywordsPredicate(Arrays.asList("Test", "saved"));
+        assertTrue(predicate.test(new InternshipBuilder().withIndustry("Test,").withTags("[saved]").build()));
     }
 }

--- a/src/test/java/seedu/address/model/internship/InternshipContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/internship/InternshipContainsKeywordsPredicateTest.java
@@ -131,23 +131,6 @@ public class InternshipContainsKeywordsPredicateTest {
     }
 
     @Test
-    public void test_emailContainsKeywords_returnsTrue() {
-        // One keyword
-        InternshipContainsKeywordsPredicate predicate =
-                new InternshipContainsKeywordsPredicate(Collections.singletonList("charlotte@example.com"));
-        assertTrue(predicate.test(new InternshipBuilder().withEmail("charlotte@example.com").build()));
-
-        // Only one matching keyword
-        predicate =
-                new InternshipContainsKeywordsPredicate(Arrays.asList("charlotte@example.com", "bernice@example.com"));
-        assertTrue(predicate.test(new InternshipBuilder().withEmail("charlotte@example.com").build()));
-
-        // Mixed-case keyword
-        predicate = new InternshipContainsKeywordsPredicate(Arrays.asList("CharLotTe@exaMPle.CoM"));
-        assertTrue(predicate.test(new InternshipBuilder().withEmail("charlotte@example.com").build()));
-    }
-
-    @Test
     public void test_emailDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
         InternshipContainsKeywordsPredicate predicate =

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -109,20 +109,6 @@ public class FindCommandSystemTest extends JobbiBotSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find address of internship in address book -> 1 internships found */
-        command = FindCommand.COMMAND_WORD + " " + "Boulevard";
-        expectedModel.updateInternship(BUSINESS3, addTag(removeAllTag(BUSINESS3), "Boulevard"));
-        ModelHelper.setSearchedList(expectedModel, BUSINESS3);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
-        /* Case: find email of internship in address book -> 1 internships found */
-        command = FindCommand.COMMAND_WORD + " " + BUSINESS3.getEmail().value;
-        expectedModel.updateInternship(BUSINESS3, addTag(removeAllTag(BUSINESS3), BUSINESS3.getEmail().value));
-        ModelHelper.setSearchedList(expectedModel, BUSINESS3);
-        assertCommandSuccess(command, expectedModel);
-        assertSelectedCardUnchanged();
-
         /* Case: find internship in address book, keyword is same as name but of different case -> 3 internship found */
         command = FindCommand.COMMAND_WORD + " EnGinEeRing";
         expectedModel.updateInternship(ENGINEERING1, addTag(removeAllTag(ENGINEERING1), "EnGinEeRing"));


### PR DESCRIPTION
Reason: Because address and email field not shown on GUI, thus even if user find, filter or sort them, he/she cannot see it (unless the internship card is selected)